### PR TITLE
Add escape highlight

### DIFF
--- a/Pest.sublime-syntax
+++ b/Pest.sublime-syntax
@@ -47,6 +47,8 @@ contexts:
   escaped-char:
     - match: '{{escaped_char}}'
       scope: constant.character.escape.pest
+    - match: '\\.'
+      scope: invalid.pest
 
   rule_def_inner: 
     - include: comments

--- a/Pest.sublime-syntax
+++ b/Pest.sublime-syntax
@@ -83,6 +83,7 @@ contexts:
                     set: trailing
               - match: \S
                 scope: invalid.pest
+                pop: true
             - include: trailing
     - match: '{{support_idents}}'
       scope: meta.function-call support.function.pest

--- a/Pest.sublime-syntax
+++ b/Pest.sublime-syntax
@@ -10,6 +10,7 @@ variables:
   trailing_op: '[*?+]'
   replaceable_support_idents: '\b(WHITESPACE|COMMENT)\b'
   support_idents: '\b(PUSH|POP|ANY|SOI|EOI|NEWLINE|ASCII_ALPHANUMERIC)\b|{{replaceable_support_idents}}'
+  escaped_char: '\\("|\\|r|n|t|0|''|x\h{2}|u\{\h{2,6}\})'
 contexts:
   main:
     - include: comments
@@ -43,6 +44,10 @@ contexts:
           pop: true
         - include: rule_def_inner
 
+  escaped-char:
+    - match: '{{escaped_char}}'
+      scope: constant.character.escape.pest
+
   rule_def_inner: 
     - include: comments
     - match: '(\^?)(")'
@@ -51,28 +56,26 @@ contexts:
         2: punctuation.definition.string.begin.pest
       push:
         - meta_scope: string.quoted.double.pest
-        - match: '\\\\'
-        - match: '\\"'
+        - include: escaped-char
         - match: '"'
           scope: punctuation.definition.string.end.pest
           set: trailing
     - match: ''''
-      captures:
-        1: keyword.operator.pest
-        2: punctuation.definition.string.begin.pest
+      scope: punctuation.definition.string.begin.pest
       push:
         - meta_scope: string.quoted.single.pest
+        - include: escaped-char
         - match: ''''
           scope: punctuation.definition.string.end.pest
           set:
             - match: '\.\.'
+              scope: keyword.operator.range.pest
               push:
               - match: ''''
-                captures:
-                  1: keyword.operator.pest
-                  2: punctuation.definition.string.begin.pest
+                scope: punctuation.definition.string.begin.pest
                 set:
                   - meta_scope: string.quoted.single.pest
+                  - include: escaped-char
                   - match: ''''
                     scope: punctuation.definition.string.end.pest
                     set: trailing

--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@ Pest syntax for Sublime Text 3.0
 
 Syntax highlighting for .pest files used with the [Pest](https://github.com/pest-parser/pest) parser.
 
-![image](https://user-images.githubusercontent.com/1019038/47756169-efbbc480-dc98-11e8-87e5-f9ab2b5f9893.png)  
+![image](https://user-images.githubusercontent.com/1019038/68603765-dbf89000-04a0-11ea-82d8-761f4c2a7399.png)  
 Grammar from: https://github.com/pest-parser/pest/blob/master/meta/src/grammar.pest


### PR DESCRIPTION
#2 
In addition, there are some other problems: 
- Unclosed range expression would make the remaining part of the file invalid;
![image](https://user-images.githubusercontent.com/31474766/68598240-65c44f80-04d9-11ea-97f2-a853534cfecb.png)
- No auto-compelete and special highlight for the built-in rules like `ASCII_DIGIT` and `ANY`.

Maybe it need to be refactored some time later.